### PR TITLE
Create SSO user struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 ### Added
 - Add code documentation ([#3](https://github.com/ristekoss/rust-sso-ui-jwt/pull/3)) ([@nayyara-airlangga])
+- Create SSO user struct ([#4](https://github.com/ristekoss/rust-sso-ui-jwt/pull/4)) ([@nayyara-airlangga])
 
 
 ## [v0.1.1] - 2022-07-29

--- a/examples/actix-web/src/main.rs
+++ b/examples/actix-web/src/main.rs
@@ -2,7 +2,7 @@ use actix_web::{self, http::header, web, App, HttpRequest, HttpResponse, HttpSer
 use serde::{Deserialize, Serialize};
 use sso_ui_jwt::{
     ticket::{validate_ticket, ValidateTicketError},
-    token::{create_token, decode_token, TokenType},
+    token::{create_token, decode_token, SSOUser, TokenType},
     SSOJWTConfig,
 };
 
@@ -59,7 +59,7 @@ async fn get_self(config: web::Data<SSOJWTConfig>, req: HttpRequest) -> HttpResp
 
                     if let Some(token) = token {
                         match decode_token(&**config, TokenType::AccessToken, &token) {
-                            Ok(data) => HttpResponse::Ok().json(data.claims),
+                            Ok(data) => HttpResponse::Ok().json(SSOUser::from(data.claims)),
                             Err(err) => HttpResponse::Unauthorized().body(err.to_string()),
                         }
                     } else {

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -4,4 +4,4 @@ pub mod handler;
 pub mod payload;
 
 pub use handler::{create_token, decode_token};
-pub use payload::{SSOJWTClaims, TokenType};
+pub use payload::{SSOJWTClaims, SSOUser, TokenType};

--- a/src/token/payload.rs
+++ b/src/token/payload.rs
@@ -33,3 +33,28 @@ pub enum TokenType {
     #[serde(rename = "refresh_token")]
     RefreshToken,
 }
+
+/// Represent's a user who's authenticated via SSO UI.
+#[derive(Deserialize, Serialize)]
+pub struct SSOUser {
+    /// User's name.
+    pub nama: String,
+    /// User's username.
+    pub username: String,
+    /// User's student id number.
+    pub npm: String,
+    /// User's organization.
+    pub organization: Organization,
+}
+
+impl From<SSOJWTClaims> for SSOUser {
+    /// Creates an [`SSOUser`] from the claims.
+    fn from(claims: SSOJWTClaims) -> Self {
+        Self {
+            nama: claims.nama,
+            username: claims.username,
+            npm: claims.npm,
+            organization: claims.organization,
+        }
+    }
+}


### PR DESCRIPTION
I created an SSO user struct which represents an authenticated user via SSO UI. This struct has the `From<SSOJWTClaims>` trait implemented so we can create a new instance of the user just from the JWT claims.

We could just pass the claims to get the user data but that would mean disclosing unnecessary information about the registered claims such as the `exp` and `iat`. That is why a separate struct would fit the job for this use case.