### PR TITLE
Reduce feature helper modules visibility to pub(super)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 - Add code documentation ([#3](https://github.com/ristekoss/rust-sso-ui-jwt/pull/3)) ([@nayyara-airlangga])
 - Create SSO user struct ([#4](https://github.com/ristekoss/rust-sso-ui-jwt/pull/4)) ([@nayyara-airlangga])
 
+### Changed
+- Reduce feature helper modules visibility to `pub(super)` ([#5](https://github.com/ristekoss/rust-sso-ui-jwt/pull/5)) ([@nayyara-airlangga])
+
 
 ## [v0.1.1] - 2022-07-29
 

--- a/src/ticket/mod.rs
+++ b/src/ticket/mod.rs
@@ -4,9 +4,9 @@
 //! authorization mechanism to the CAS server and if valid will return an XML response that
 //! contains the user data if successful and an error if it fails.
 
-pub mod error;
-pub mod handler;
-pub mod payload;
+pub(super) mod error;
+pub(super) mod handler;
+pub(super) mod payload;
 
 pub use error::ValidateTicketError;
 pub use handler::validate_ticket;

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -1,7 +1,7 @@
 //! JWT utilities and claims for user data.
 
-pub mod handler;
-pub mod payload;
+pub(super) mod handler;
+pub(super) mod payload;
 
 pub use handler::{create_token, decode_token};
 pub use payload::{SSOJWTClaims, SSOUser, TokenType};


### PR DESCRIPTION
I reduced the visibility for modules which are not the feature modules for the library. I call these helper modules as they help in separating internal code within a feature for increased readability. This will also help reduce noise in the `docs.rs` as now only the necessary components of a feature module are exposed to the documentation.

I reduced it to `pub(super)` instead of `pub(crate)` because if features need to integrate with each other, we can use the re-exports from the feature module instead of the feature helper modules.