### PR TITLE
Add get single organization handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Notable changes to this project will be documented here.
+All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog], and this project adheres to [Semantic Versioning].
 
@@ -9,9 +9,11 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 ### Added
 - Add code documentation ([#3](https://github.com/ristekoss/rust-sso-ui-jwt/pull/3)) ([@nayyara-airlangga])
 - Create SSO user struct ([#4](https://github.com/ristekoss/rust-sso-ui-jwt/pull/4)) ([@nayyara-airlangga])
+- Add get single organization handler ([#6](https://github.com/ristekoss/rust-sso-ui-jwt/pull/6)) ([@nayyara-airlangga])
 
 ### Changed
 - Reduce feature helper modules visibility to `pub(super)` ([#5](https://github.com/ristekoss/rust-sso-ui-jwt/pull/5)) ([@nayyara-airlangga])
+- Remove `Clone` and `PartialEq` trait implementation from the `Organization` struct ([#6](https://github.com/ristekoss/rust-sso-ui-jwt/pull/6)) ([@nayyara-airlangga])
 
 
 ## [v0.1.1] - 2022-07-29

--- a/src/orgs/mod.rs
+++ b/src/orgs/mod.rs
@@ -44,3 +44,43 @@ pub struct Organization {
 pub fn get_organizations() -> HashMap<String, Organization> {
     serde_json::from_str(ORG_CODES).unwrap()
 }
+
+/// Gets a single organization based on the organization code.
+///
+/// # Options
+///
+/// Because an organization with the given organization code could possibly not exist, this
+/// function simply returns an [`Option`] and leave how to handle the output to the user.
+///
+/// # Examples
+///
+/// ```rust
+/// use sso_ui_jwt::orgs::{get_organization, Organization};
+///
+/// let org_code = "01.00.12.01";
+/// let another_org_code = "Random org code";
+///
+/// assert_eq!(
+///     Some(
+///         Organization {
+///             faculty: String::from("Ilmu Komputer"),
+///             short_faculty: String::from("Fasilkom"),
+///             major: String::from("Ilmu Komputer (Computer Science)"),
+///             program: String::from("S1 Reguler (Undergraduate Program)"),
+///         }
+///     ),
+///     get_organization(org_code),
+/// );
+///
+/// assert_eq!(
+///     None,
+///     get_organization(another_org_code),
+/// );
+/// ```
+pub fn get_organization(org_code: &str) -> Option<Organization> {
+    let mut orgs = get_organizations();
+
+    // `remove()` moves the value out of the `orgs` hash map so the value we return does not have a
+    // dangling reference, making this code safe.
+    orgs.remove(org_code)
+}

--- a/src/orgs/mod.rs
+++ b/src/orgs/mod.rs
@@ -11,7 +11,7 @@ mod orgcode;
 use orgcode::ORG_CODES;
 
 /// Represents an academic organization in UI.
-#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Organization {
     /// Name of the organization's faculty.
     pub faculty: String,
@@ -34,12 +34,10 @@ pub struct Organization {
 /// let orgs = get_organizations();
 /// let org = orgs.get("01.00.12.01").unwrap();
 ///
-/// assert_eq!(org, &Organization {
-///     faculty: String::from("Ilmu Komputer"),
-///     short_faculty: String::from("Fasilkom"),
-///     major: String::from("Ilmu Komputer (Computer Science)"),
-///     program: String::from("S1 Reguler (Undergraduate Program)"),
-/// });
+/// assert_eq!(org.faculty, "Ilmu Komputer");
+/// assert_eq!(org.short_faculty, "Fasilkom");
+/// assert_eq!(org.major, "Ilmu Komputer (Computer Science)");
+/// assert_eq!(org.program, "S1 Reguler (Undergraduate Program)");
 /// ```
 pub fn get_organizations() -> HashMap<String, Organization> {
     serde_json::from_str(ORG_CODES).unwrap()
@@ -55,27 +53,15 @@ pub fn get_organizations() -> HashMap<String, Organization> {
 /// # Examples
 ///
 /// ```rust
-/// use sso_ui_jwt::orgs::{get_organization, Organization};
+/// use sso_ui_jwt::orgs::get_organization;
 ///
 /// let org_code = "01.00.12.01";
-/// let another_org_code = "Random org code";
+/// let org = get_organization(org_code).unwrap();
 ///
-/// assert_eq!(
-///     Some(
-///         Organization {
-///             faculty: String::from("Ilmu Komputer"),
-///             short_faculty: String::from("Fasilkom"),
-///             major: String::from("Ilmu Komputer (Computer Science)"),
-///             program: String::from("S1 Reguler (Undergraduate Program)"),
-///         }
-///     ),
-///     get_organization(org_code),
-/// );
-///
-/// assert_eq!(
-///     None,
-///     get_organization(another_org_code),
-/// );
+/// assert_eq!(org.faculty, "Ilmu Komputer");
+/// assert_eq!(org.short_faculty, "Fasilkom");
+/// assert_eq!(org.major, "Ilmu Komputer (Computer Science)");
+/// assert_eq!(org.program, "S1 Reguler (Undergraduate Program)");
 /// ```
 pub fn get_organization(org_code: &str) -> Option<Organization> {
     let mut orgs = get_organizations();

--- a/src/token/handler.rs
+++ b/src/token/handler.rs
@@ -4,7 +4,7 @@ use jsonwebtoken::{
     decode, encode, errors::Result, DecodingKey, EncodingKey, Header, TokenData, Validation,
 };
 
-use crate::{orgs::get_organizations, ticket::ServiceResponse, SSOJWTConfig};
+use crate::{orgs::get_organization, ticket::ServiceResponse, SSOJWTConfig};
 
 use super::{payload::SSOJWTClaims, TokenType};
 
@@ -70,9 +70,7 @@ pub fn create_token(
     let exp = now.timestamp() + token_exp_time;
 
     let user_attributes = service_res.authentication_success.unwrap();
-
-    let orgs = get_organizations();
-    let org = orgs.get(&user_attributes.attributes.kd_org).unwrap();
+    let organization = get_organization(&user_attributes.attributes.kd_org).unwrap();
 
     let claims = SSOJWTClaims {
         iat: now.timestamp(),
@@ -80,7 +78,7 @@ pub fn create_token(
         username: user_attributes.user,
         nama: user_attributes.attributes.nama,
         npm: user_attributes.attributes.npm,
-        organization: org.clone(),
+        organization,
     };
 
     encode(


### PR DESCRIPTION
I decided to add a handler to get a single organization by its organization code. This is so that a library user could get the organization they need without needing to get all organizations by themselves (this is done internally in the new handler) and also without having to get the organization they need from the hash map themselves.

An additional side effect from this is that we could also remove `Clone` trait that would otherwise be needed if we just had the `orgs::get_organizations` as that would return a hash map and getting a value from a hash map would return a reference instead of the actual value required in the `SSOJWTClaims` and `SSOUser` structs. The new handler would move the value out of the hash map, meaning there is no need for cloning.