### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 ## [Unreleased]
 
+No changes have been made since the last release.
+
+
+## [v0.2.0] - 2022-07-30
+
+Thanks to the following for their contributions:
+- [@nayyara-airlangga]
+
 ### Added
 - Add code documentation ([#3](https://github.com/ristekoss/rust-sso-ui-jwt/pull/3)) ([@nayyara-airlangga])
 - Create SSO user struct ([#4](https://github.com/ristekoss/rust-sso-ui-jwt/pull/4)) ([@nayyara-airlangga])
@@ -40,7 +48,8 @@ Thanks to the following for their contributions:
 [contributing.md]: https://github.com/ristekoss/rust-sso-ui-jwt/tree/main/CONTRIBUTING.md
 
 <!-- VERSION COMPARISON -->
-[Unreleased]: https://github.com/ristekoss/rust-sso-ui-jwt/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/ristekoss/rust-sso-ui-jwt/compare/v0.2.0...HEAD
+[v0.2.0]: https://github.com/ristekoss/rust-sso-ui-jwt/compare/v0.1.1...v0.2.0
 [v0.1.1]: https://github.com/ristekoss/rust-sso-ui-jwt/compare/v0.1.0...v0.1.1
 [v0.1.0]: https://github.com/ristekoss/rust-sso-ui-jwt/tree/v0.1.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sso-ui-jwt"
 description = "Rust library for JWT utilities from SSO UI"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 keywords = ["sso", "jwt", "ristekoss", "ristekcsui", "universitasindonesia"]
 authors = ["RISTEK Open Source <team@ristek.cs.ui.ac.id>"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ That's why we decided to make this library.
 It parses the response data into a JSON format and we provide
 the SSO ticket validation mechanism as well as JWT utilities for the data.
 
+## Documentation
+
+You can view the project's documentation in it's [docs.rs](https://docs.rs/sso-ui-jwt/latest/sso_ui_jwt) website.
+
 ## Usage
 
 See the [examples](https://github.com/ristekoss/rust-sso-ui-jwt/tree/main/examples) for reference on using this library.
@@ -23,7 +27,7 @@ Add this to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-sso-ui-jwt = "0.1"
+sso-ui-jwt = "0.2"
 ```
 
 ## Features
@@ -32,7 +36,7 @@ Enabling or disabling features can be done by configuring the library from `Carg
 
 ```toml
 [dependencies.sso-ui-jwt]
-version = "0.1"
+version = "0.2"
 features = ["log"]
 ```
 
@@ -41,6 +45,10 @@ As of right now, there are no default features implemented.
 Full list of features:
 
 - **`log`**: Logs the messages within the library
+
+## Contributing
+
+If you'd like to contribute to this project, please read our [contributing guidelines](https://github.com/ristekoss/rust-sso-ui-jwt/tree/main/CONTRIBUTING.md) **before creating pull requsts**.
 
 ## Maintainers
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! sso-ui-jwt = "0.1"
+//! sso-ui-jwt = "0.2"
 //! ```
 //!
 //! # Features
@@ -30,7 +30,7 @@
 //!
 //! ```toml
 //! [dependencies.sso-ui-jwt]
-//! version = "0.1"
+//! version = "0.2"
 //! features = ["log"]
 //! ```
 //!

--- a/src/orgs/mod.rs
+++ b/src/orgs/mod.rs
@@ -29,7 +29,7 @@ pub struct Organization {
 /// # Examples
 ///
 /// ```rust
-/// use sso_ui_jwt::orgs::{get_organizations, Organization};
+/// use sso_ui_jwt::orgs::get_organizations;
 ///
 /// let orgs = get_organizations();
 /// let org = orgs.get("01.00.12.01").unwrap();


### PR DESCRIPTION
I believe that the current changes are good enough to release a new version of [`sso-ui-jwt`](https://crates.io/crates/sso-ui-jwt) to [`crates.io`](https://crates.io).