### PR TITLE
Create code style workflow

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,43 @@
+name: Style
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  lint:
+    name: Clippy
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        
+      - name: Install toolchain
+        run: |
+          rustup install stable
+          rustup component add clippy
+        
+      - name: Run clippy
+        run: cargo clippy --workspace --tests -- -D warnings
+        
+  format:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        
+      - name: Install toolchain
+        run: |
+          rustup install stable
+          rustup component add rustfmt
+      
+      - name: Run rustfmt
+        run: cargo fmt --check --all

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+     - '**/*.rs'
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 ## [Unreleased]
 
-No changes have been made since the last release.
+### Added
+- Create code style workflow ([#10](https://github.com/ristekoss/rust-sso-ui-jwt/pull/10)) ([@nayyara-airlangga])
+
+### Fixed
+- Fix `actix-web-example` to match the code standards ([#10](https://github.com/ristekoss/rust-sso-ui-jwt/pull/10)) ([@nayyara-airlangga])
 
 
 ## [v0.2.0] - 2022-07-30

--- a/examples/actix-web/src/main.rs
+++ b/examples/actix-web/src/main.rs
@@ -18,11 +18,11 @@ struct TokenRes {
 
 async fn login(config: web::Data<SSOJWTConfig>, query: web::Query<LoginQuery>) -> HttpResponse {
     if let Some(ticket) = &query.ticket {
-        let res = validate_ticket(&**config, &ticket).await;
+        let res = validate_ticket(&**config, ticket).await;
 
         match res {
             Ok(res) => {
-                let token = create_token(&config, TokenType::AccessToken, res.clone()).unwrap();
+                let token = create_token(&config, TokenType::AccessToken, res).unwrap();
 
                 let creds = TokenRes { token };
                 HttpResponse::Ok().json(creds)
@@ -58,7 +58,7 @@ async fn get_self(config: web::Data<SSOJWTConfig>, req: HttpRequest) -> HttpResp
                     let token = header_vec.get(1);
 
                     if let Some(token) = token {
-                        match decode_token(&**config, TokenType::AccessToken, &token) {
+                        match decode_token(&**config, TokenType::AccessToken, token) {
                             Ok(data) => HttpResponse::Ok().json(SSOUser::from(data.claims)),
                             Err(err) => HttpResponse::Unauthorized().body(err.to_string()),
                         }


### PR DESCRIPTION
This PR is made as an implementation to issue (#9) regarding a workflow for code standards. With this PR, I've implemented workflows for the linting and formatting of the code via `clippy` and `rustfmt`.