### PR TITLE
Fix ValidateTicketError for xml response parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 ### Added
 - Create code style workflow ([#10](https://github.com/ristekoss/rust-sso-ui-jwt/pull/10)) ([@nayyara-airlangga])
 
+## Removed
+- Remove `BadRequest` from `ValidateTicketError` ([#11](https://github.com/ristekoss/rust-sso-ui-jwt/pull/11)) ([@nayyara-airlangga])
+
 ### Fixed
 - Fix `actix-web-example` to match the code standards ([#10](https://github.com/ristekoss/rust-sso-ui-jwt/pull/10)) ([@nayyara-airlangga])
+- Fix `ValidateTicketError` for xml response parsing ([#11](https://github.com/ristekoss/rust-sso-ui-jwt/pull/11)) ([@nayyara-airlangga])
 
 
 ## [v0.2.0] - 2022-07-30

--- a/src/ticket/error.rs
+++ b/src/ticket/error.rs
@@ -7,8 +7,6 @@ pub enum ValidateTicketError {
     AuthenticationFailed,
     /// Errors regarding the validation request.
     ReqwestError,
-    /// A bad request to the CAS server.
-    BadRequest,
     /// Error parsing the XML response.
     XMLParsingError,
 }


### PR DESCRIPTION
After further inspection, the `BadRequest` error for ticket validation is misused and deemed ambiguous for the purpose of the function. Parsing a response into text is something that won't cause errors for almost all use cases. On the other hand, the `XMLParsingError` was misplaced as it was supposed to be implemented for when the response text is being parsed to it's XML struct. This PR fixes that issue and will probably bump the version to v0.3.0 as it will introduce changes to the public API's structure for ticket validation errors.