### PR TITLE
Bump to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,17 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 ## [Unreleased]
 
+No changes have been made since the last release.
+
+## [v0.3.0] - 2022-07-31
+
+Thanks to the following for their contributions:
+- [@nayyara-airlangga]
+
 ### Added
 - Create code style workflow ([#10](https://github.com/ristekoss/rust-sso-ui-jwt/pull/10)) ([@nayyara-airlangga])
 
-## Removed
+### Removed
 - Remove `BadRequest` from `ValidateTicketError` ([#11](https://github.com/ristekoss/rust-sso-ui-jwt/pull/11)) ([@nayyara-airlangga])
 
 ### Fixed
@@ -56,7 +63,8 @@ Thanks to the following for their contributions:
 [contributing.md]: https://github.com/ristekoss/rust-sso-ui-jwt/tree/main/CONTRIBUTING.md
 
 <!-- VERSION COMPARISON -->
-[Unreleased]: https://github.com/ristekoss/rust-sso-ui-jwt/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/ristekoss/rust-sso-ui-jwt/compare/v0.3.0...HEAD
+[v0.3.0]: https://github.com/ristekoss/rust-sso-ui-jwt/compare/v0.2.0...v0.3.0
 [v0.2.0]: https://github.com/ristekoss/rust-sso-ui-jwt/compare/v0.1.1...v0.2.0
 [v0.1.1]: https://github.com/ristekoss/rust-sso-ui-jwt/compare/v0.1.0...v0.1.1
 [v0.1.0]: https://github.com/ristekoss/rust-sso-ui-jwt/tree/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sso-ui-jwt"
 description = "Rust library for JWT utilities from SSO UI"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 keywords = ["sso", "jwt", "ristekoss", "ristekcsui", "universitasindonesia"]
 authors = ["RISTEK Open Source <team@ristek.cs.ui.ac.id>"]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-sso-ui-jwt = "0.2"
+sso-ui-jwt = "0.3"
 ```
 
 ## Features
@@ -36,7 +36,7 @@ Enabling or disabling features can be done by configuring the library from `Carg
 
 ```toml
 [dependencies.sso-ui-jwt]
-version = "0.2"
+version = "0.3"
 features = ["log"]
 ```
 

--- a/examples/actix-web/Cargo.toml
+++ b/examples/actix-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-example"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! sso-ui-jwt = "0.2"
+//! sso-ui-jwt = "0.3"
 //! ```
 //!
 //! # Features
@@ -30,7 +30,7 @@
 //!
 //! ```toml
 //! [dependencies.sso-ui-jwt]
-//! version = "0.2"
+//! version = "0.3"
 //! features = ["log"]
 //! ```
 //!


### PR DESCRIPTION
With the update to the API regarding ticket validation errors and other fixes and improvements, in my opinion, this is a good time to bump to `v0.3.0`