### PR TITLE
Remove dotenv and unused tokio features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 ## [Unreleased]
 
-No changes have been made since the last release.
+### Removed
+- Remove `dotenv` and unused `tokio` features ([#13](https://github.com/ristekoss/rust-sso-ui-jwt/pull/13)) ([@nayyara-airlangga])
 
 ## [v0.3.0] - 2022-07-31
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 [workspace]
 members = ["examples/*"]
 
+[features]
+log = ["dep:log"]
+
 [dependencies]
 jsonwebtoken = "8.1.1"
 serde_json = "1.0.82"
 strong-xml = "0.6.3"
-
-[features]
-log = ["dep:log"]
 
 [dependencies.chrono]
 version = "0.4.19"
@@ -41,7 +41,4 @@ features = ["derive"]
 
 [dependencies.tokio]
 version = "1.20.1"
-features = ["full"]
-
-[dev-dependencies.dotenv]
-version = "0.15.0"
+features = ["rt-multi-thread", "macros"]


### PR DESCRIPTION
The `dotenv` crate is not used anywhere in the project as of right now. The project also only used the `rt-multi-thread` and `macros` feature from `tokio`. With these reasons, I decided to remove them from the project's dependencies