### PR TITLE
Make ticket validation request to be synchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 ## [Unreleased]
 
-No changes have been made.
+### Changed
+- Make ticket validation request to be synchronous ([#16](https://github.com/ristekoss/rust-sso-ui-jwt/pull/16)) ([@nayyara-airlangga])
+- Rename `ReqwestError` to `RequestError` ([#16](https://github.com/ristekoss/rust-sso-ui-jwt/pull/16)) ([@nayyara-airlangga])
+
+### Removed
+- Remove `tokio` and replace `reqwest` with `http_req` ([#16](https://github.com/ristekoss/rust-sso-ui-jwt/pull/16)) ([@nayyara-airlangga])
 
 
 ## [v0.3.1] - 2022-07-31

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = ["examples/*"]
 log = ["dep:log"]
 
 [dependencies]
+http_req = "0.8.1"
 jsonwebtoken = "8.1.1"
 serde_json = "1.0.82"
 strong-xml = "0.6.3"
@@ -31,14 +32,6 @@ features = ["serde"]
 version = "0.4.17"
 optional = true
 
-[dependencies.reqwest]
-version = "0.11.11"
-features = ["json"]
-
 [dependencies.serde]
 version = "1.0.140"
 features = ["derive"]
-
-[dependencies.tokio]
-version = "1.20.1"
-features = ["rt-multi-thread", "macros"]

--- a/examples/actix-web/Cargo.toml
+++ b/examples/actix-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-example"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/actix-web/src/main.rs
+++ b/examples/actix-web/src/main.rs
@@ -18,7 +18,7 @@ struct TokenRes {
 
 async fn login(config: web::Data<SSOJWTConfig>, query: web::Query<LoginQuery>) -> HttpResponse {
     if let Some(ticket) = &query.ticket {
-        let res = validate_ticket(&**config, ticket).await;
+        let res = validate_ticket(&**config, ticket);
 
         match res {
             Ok(res) => {

--- a/src/ticket/error.rs
+++ b/src/ticket/error.rs
@@ -6,7 +6,7 @@ pub enum ValidateTicketError {
     /// Failed ticket authentication.
     AuthenticationFailed,
     /// Errors regarding the validation request.
-    ReqwestError,
+    RequestError,
     /// Error parsing the XML response.
     XMLParsingError,
 }

--- a/src/ticket/handler.rs
+++ b/src/ticket/handler.rs
@@ -15,7 +15,7 @@ use super::{ServiceResponse, ValidateTicketError};
 /// # Errors
 ///
 /// - [`AuthenticationFailed`][validate_ticket_error]: Failed ticket authentication
-/// - [`ReqwestError`][validate_ticket_error]: Validation request caused an error
+/// - [`RequestError`][validate_ticket_error]: Validation request caused an error
 /// - [`XMLParsingError`][validate_ticket_error]: Error parsing XML response
 ///
 /// [validate_ticket_error]: crate::ticket::error::ValidateTicketError
@@ -69,7 +69,7 @@ pub fn validate_ticket(
             #[cfg(feature = "log")]
             log::error!("{}", _err);
 
-            return Err(ValidateTicketError::ReqwestError);
+            return Err(ValidateTicketError::RequestError);
         }
     };
 


### PR DESCRIPTION
I discovered an http client called `http_req` and it provides the ability to make synchronous requests. This is enough for our project and works great with the existing code.

This will also give us the ability to remove heavy and asynchronous dependencies such as `tokio` and `reqwest` from the project to make it slimmer.