### PR TITLE
Bump to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 ## [Unreleased]
 
+No changes have been made.
+
+
+## [v0.4.0] - 2022-08-02
+
+Thanks to the following for their contributions:
+- [@nayyara-airlangga]
+
 ### Changed
 - Make ticket validation request to be synchronous ([#16](https://github.com/ristekoss/rust-sso-ui-jwt/pull/16)) ([@nayyara-airlangga])
 - Rename `ReqwestError` to `RequestError` ([#16](https://github.com/ristekoss/rust-sso-ui-jwt/pull/16)) ([@nayyara-airlangga])
@@ -78,7 +86,8 @@ Thanks to the following for their contributions:
 [contributing.md]: https://github.com/ristekoss/rust-sso-ui-jwt/tree/main/CONTRIBUTING.md
 
 <!-- VERSION COMPARISON -->
-[Unreleased]: https://github.com/ristekoss/rust-sso-ui-jwt/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/ristekoss/rust-sso-ui-jwt/compare/v0.4.0...HEAD
+[v0.4.0]: https://github.com/ristekoss/rust-sso-ui-jwt/compare/v0.3.1...v0.4.0
 [v0.3.1]: https://github.com/ristekoss/rust-sso-ui-jwt/compare/v0.3.0...v0.3.1
 [v0.3.0]: https://github.com/ristekoss/rust-sso-ui-jwt/compare/v0.2.0...v0.3.0
 [v0.2.0]: https://github.com/ristekoss/rust-sso-ui-jwt/compare/v0.1.1...v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sso-ui-jwt"
 description = "Rust library for JWT utilities from SSO UI"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 keywords = ["sso", "jwt", "ristekoss", "ristekcsui", "universitasindonesia"]
 authors = ["RISTEK Open Source <team@ristek.cs.ui.ac.id>"]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add this to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-sso-ui-jwt = "0.3"
+sso-ui-jwt = "0.4"
 ```
 
 ## Features
@@ -36,7 +36,7 @@ Enabling or disabling features can be done by configuring the library from `Carg
 
 ```toml
 [dependencies.sso-ui-jwt]
-version = "0.3"
+version = "0.4"
 features = ["log"]
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! sso-ui-jwt = "0.3"
+//! sso-ui-jwt = "0.4"
 //! ```
 //!
 //! # Features
@@ -30,7 +30,7 @@
 //!
 //! ```toml
 //! [dependencies.sso-ui-jwt]
-//! version = "0.3"
+//! version = "0.4"
 //! features = ["log"]
 //! ```
 //!


### PR DESCRIPTION
With change in how the `validate_ticket` function works to synchronous, change to the public API, and dependency removals, I believe it's time for another update